### PR TITLE
Set line width limit for imports to 100

### DIFF
--- a/haskell.md
+++ b/haskell.md
@@ -27,7 +27,8 @@ Note for Serokell people:
 ### Line Length
 
 You *should* keep maximum line length below *80 characters*. If necessary, you
-*may* use up to *100 characters*, although this is discouraged.
+*may* use up to *100 characters*, although this is discouraged. You *should*
+wrap imports at *100 characters*.
 
 ### Indentation
 


### PR DESCRIPTION
Problem: Haskell style guide states that all lines *should* be less
than 80 characters long. However, for imports this is not so practical,
because import lists are usually not really interesting and if the
limit is small, imports occupy more lines. It leads to more conflicts.
Solution: set line width limit for imports to 100.