### PR TITLE
Allow declaring records with multiple constructors

### DIFF
--- a/haskell.md
+++ b/haskell.md
@@ -344,8 +344,13 @@ data Person = Person
   } deriving (Eq, Show)
 ```
 
-You *must* not declare records with multiple constructors because their getters
-are partial functions.
+You *can* declare records with multiple constructors but only if
+[`-Wincomplete-record-updates`](http://downloads.haskell.org/ghc/7.0.4/docs/html/users_guide/options-sanity.html)
+GHC flag (also implied by `-Weverything`) is enabled globally for the project.
+In such case you won't be able to access or modify objects via partial records,
+but features provided by [`-NamedFieldPuns`](http://downloads.haskell.org/~ghc/8.6.2/docs/html/users_guide/glasgow_exts.html#extension-NamedFieldPuns)
+and [`-XRecordWildCards`](http://downloads.haskell.org/~ghc/8.6.2/docs/html/users_guide/glasgow_exts.html#extension-RecordWildCards)
+extensions remain allowed.
 
 As usual, separate type classes with `, ` (comma and a space).
 


### PR DESCRIPTION
The previously written rule which prohibits records declarations in
datatypes with several constructors does not make sense to me.

Yes, it prevents you from creating partial records, but there
is `-Wincomplete-record-updates` extension which does not allow you
to shoot in your leg while using those anyway.

Herewith I see at least one use case for declaring such datatype.
In Serokell we used to define exceptions as a datatype with many
constructors, each corresponding to single error scenario.
Good practices suggest that you attach all possible information
to exception, at least to ease further debugging.
It seems reasonable to say that constructing and using exception with
named fields is much simpler (i.e. less error-prone and more readable),
especially when a constructor has several fields of the same type.