### PR TITLE
Add requirement for qualified imports

### DIFF
--- a/haskell.md
+++ b/haskell.md
@@ -320,6 +320,33 @@ Imports *should* be grouped in the following order:
 
 Put a blank line between each group of imports.
 
+For qualified imports you *should* use `ImportQualifiedPost` [extension](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/import_qualified_post.html).
+In case the package supports GHC < 8.10.1 you *should* put `qualified` imports in
+separate groups, respecting the order.
+Examples:
+
+For GHC >= 8.10.1
+``` haskell
+import Data.Char (isUpper)
+import Data.Map qualified as Map
+import Data.Text qualified as Text
+
+import My.Helpers (helper)
+import My.Lib qualified as Lib
+```
+
+For GHC < 8.10.1
+``` haskell
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+
+import Data.Char (isUpper)
+
+import qualified My.Lib as Lib
+
+import My.Helpers (helper)
+```
+
 The imports in each group should be sorted alphabetically. `stylish-haskell`
 with [our config][stylish-haskell] can do this for you.
 


### PR DESCRIPTION
Problem:
In projects we can see a lot of imports, and when `qualified` imports
mixed with regular imports it's become hard to read import list.
Let's compare this to import lists:

``` haskell
import CMarkGFM (Node (..), NodeType (..), PosInfo (..), commonmarkToNode)
import Control.Lens ((%=))
import Control.Monad.Trans.Except (Except, runExcept, throwE)
import Data.Aeson.TH (deriveFromJSON)
import qualified Data.ByteString.Lazy as BSL
import Data.Char (isSpace)
import Data.Default (Default (..))
import qualified Data.Text as T
import qualified Data.Text.Lazy as LT
import Fmt (Buildable (..), blockListF, nameF, (+|), (|+))

import Xrefcheck.Core
import Xrefcheck.Scan
import Xrefcheck.Util
```

For GHC < 8.10.1
``` haskell
import qualified Data.ByteString.Lazy as BSL
import qualified Data.Text as T
import qualified Data.Text.Lazy as LT

import CMarkGFM (Node (..), NodeType (..), PosInfo (..), commonmarkToNode)
import Control.Lens ((%=))
import Control.Monad.Trans.Except (Except, runExcept, throwE)
import Data.Aeson.TH (deriveFromJSON)
import Data.Char (isSpace)
import Data.Default (Default (..))
import Fmt (Buildable (..), blockListF, nameF, (+|), (|+))

import Xrefcheck.Core
import Xrefcheck.Scan
import Xrefcheck.Util
```

For GHC >= 8.10.1
``` haskell
import CMarkGFM (Node (..), NodeType (..), PosInfo (..), commonmarkToNode)
import Control.Lens ((%=))
import Control.Monad.Trans.Except (Except, runExcept, throwE)
import Data.Aeson.TH (deriveFromJSON)
import Data.ByteString.Lazy qualified as BSL
import Data.Char (isSpace)
import Data.Default (Default (..))
import Data.Text qualified as T
import Data.Text.Lazy qualified as LT
import Fmt (Buildable (..), blockListF, nameF, (+|), (|+))

import Xrefcheck.Core
import Xrefcheck.Scan
import Xrefcheck.Util
```

We can see that in the second example it becomes much easier to determine
which imports is qualified and to find it's names.

Solution:
Add requirement to use `ImportQualifiedPost` [extension](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/import_qualified_post.html)
or put `qualified` imports in separate groups (for GHC < 8.10.1, because
the extension was presented at version 8.10.1), respecting the order.